### PR TITLE
"masterminds/html5": "^2.7"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "querypath/QueryPath": ">=3.0.4",
         "sebastian/diff": "^1.2 || ^2 || ^3",
         "marc1706/fast-image-size": "1.*",
-        "masterminds/html5": "^2.6",
+        "masterminds/html5": "^2.7",
         "sabberworm/php-css-parser": "^8.0.0",
         "guzzlehttp/guzzle": "~6.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "querypath/QueryPath": ">=3.0.4",
         "sebastian/diff": "^1.2 || ^2 || ^3",
         "marc1706/fast-image-size": "1.*",
-        "masterminds/html5": "~2.3.0",
+        "masterminds/html5": "^2.7",
         "sabberworm/php-css-parser": "^8.0.0",
         "guzzlehttp/guzzle": "~6.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "querypath/QueryPath": ">=3.0.4",
         "sebastian/diff": "^1.2 || ^2 || ^3",
         "marc1706/fast-image-size": "1.*",
-        "masterminds/html5": "^2.7",
+        "masterminds/html5": "^2.6",
         "sabberworm/php-css-parser": "^8.0.0",
         "guzzlehttp/guzzle": "~6.1"
     },

--- a/src/Utility/AMPDOMTreeBuilder.php
+++ b/src/Utility/AMPDOMTreeBuilder.php
@@ -44,12 +44,7 @@ class AMPDOMTreeBuilder extends DOMTreeBuilder
         return $this->scanner;
     }
 
-    /**
-     * AMPDOMTreeBuilder constructor.
-     * @param InputStream $inputstream
-     * @param array $options
-     */
-    public function __construct(InputStream $inputstream, array $options = [])
+    public function __construct($inputstream, array $options = [])
     {
         // We embed a scanner so that $this->startTag() knows the current line number
         $this->scanner = new Scanner($inputstream);

--- a/src/Utility/AMPHTML5.php
+++ b/src/Utility/AMPHTML5.php
@@ -39,14 +39,12 @@ class AMPHTML5 extends HTML5
      * Similar to \Masterminds\HTML5::parse() method in superclass but we use our custom (sub-classed) tokenizer and DOM tree
      * builder to achieve desired effect of adding a line number attribute to each tag of the output DOM document.
      *
-     * @param InputStream $inputstream
-     * @param array $options
      * @return \DOMDocument
      */
-    public function parse(InputStream $inputstream, array $options = [])
+    public function parse($inputstream, array $options = [])
     {
         // User options override default options in $this->options
-        $final_options = array_merge($this->options, $options);
+        $final_options = array_merge($this->getOptions(), $options);
         $amp_tree_builder = new AMPDOMTreeBuilder($inputstream, $final_options);
         $amp_tokenizer = new AMPTokenizer($amp_tree_builder);
 


### PR DESCRIPTION
Old version blocks Symfony 4.3 upgrade:

```
Problem 1
    - Conclusion: remove lullabot/amp dev-twitter-fix
    - Conclusion: don't install lullabot/amp dev-twitter-fix
    - Conclusion: don't install symfony/symfony v4.4.7
    - Conclusion: don't install symfony/symfony v4.4.6
    - Conclusion: don't install symfony/symfony v4.4.5
    - Conclusion: don't install symfony/symfony v4.4.4
    - Conclusion: don't install symfony/symfony v4.4.3
    - Conclusion: don't install symfony/symfony v4.4.2
    - Conclusion: don't install symfony/symfony v4.4.1
    - Installation request for lullabot/amp dev-twitter-fix -> satisfiable by lullabot/amp[dev-twitter-fix].
    - Conclusion: don't install symfony/symfony v4.4.0
    - lullabot/amp dev-twitter-fix requires masterminds/html5 ~2.3.0 -> satisfiable by masterminds/html5[2.3.1, 2.3.0].
    - masterminds/html5 2.3.0 conflicts with symfony/symfony[v4.3.11].
    - masterminds/html5 2.3.1 conflicts with symfony/symfony[v4.3.11].
    - symfony/symfony v4.3.11 conflicts with masterminds/html5[2.3.1].
    - symfony/symfony v4.3.11 conflicts with masterminds/html5[2.3.1].
    - Installation request for symfony/symfony ^4.3.11 -> satisfiable by symfony/symfony[v4.3.11, v4.4.0, v4.4.1, v4.4.2, v4.4.3, v4.4.4, v4.4.5, v4.4.6, v4.4.7].
```

Can you give it a spin please and see if it works?