### PR TITLE
Support sebastian/diff 4. No BC breaks.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require" : {
         "php" : ">=5.5.0",
         "querypath/QueryPath": ">=3.0.4",
-        "sebastian/diff": "^1.2 || ^2 || ^3",
+        "sebastian/diff": "^1.2 || ^2 || ^3 || ^4",
         "marc1706/fast-image-size": "1.*",
         "masterminds/html5": "^2.7",
         "sabberworm/php-css-parser": "^8.0.0",


### PR DESCRIPTION
https://github.com/sebastianbergmann/diff/blob/master/ChangeLog.md

This allows upgrading phpunit to version 9:

```
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Conclusion: remove lullabot/amp dev-chesscom
    - Conclusion: don't install lullabot/amp dev-chesscom
    - Conclusion: don't install phpunit/phpunit 9.5.3
    - Conclusion: don't install sebastian/diff 3.0.3
    - Conclusion: don't install phpunit/phpunit 9.5.2
    - Conclusion: don't install phpunit/phpunit 9.5.0
    - Conclusion: don't install phpunit/phpunit 9.5.1|remove sebastian/diff 3.0.2
    - Conclusion: don't install phpunit/phpunit 9.5.1|don't install sebastian/diff 3.0.2
    - Installation request for lullabot/amp dev-chesscom#1.2.1 -> satisfiable by lullabot/amp[dev-chesscom].
    - Installation request for phpunit/phpunit ^9.5 -> satisfiable by phpunit/phpunit[9.5.0, 9.5.1, 9.5.2, 9.5.3].
    - lullabot/amp dev-chesscom requires sebastian/diff ^1.2 || ^2 || ^3 -> satisfiable by sebastian/diff[3.0.2, 1.2.0, 1.3.0, 1.4.0, 1.4.1, 1.4.2, 1.4.3, 2.0.1, 3.0.0, 3.0.1, 3.0.3].
    - Can only install one of: sebastian/diff[4.0.3, 3.0.0].
    - Can only install one of: sebastian/diff[4.0.3, 3.0.1].
    - Can only install one of: sebastian/diff[4.0.3, 1.2.0].
    - Can only install one of: sebastian/diff[4.0.3, 1.3.0].
    - Can only install one of: sebastian/diff[4.0.3, 1.4.0].
    - Can only install one of: sebastian/diff[4.0.3, 1.4.1].
    - Can only install one of: sebastian/diff[4.0.3, 1.4.2].
    - Can only install one of: sebastian/diff[4.0.3, 1.4.3].
    - Can only install one of: sebastian/diff[4.0.3, 2.0.1].
    - Can only install one of: sebastian/diff[4.0.3, 3.0.2].
    - phpunit/phpunit 9.5.1 requires sebastian/diff ^4.0.3 -> satisfiable by sebastian/diff[4.0.3, 4.0.4].
    - Conclusion: don't install sebastian/diff 4.0.4|keep sebastian/diff 3.0.2
```